### PR TITLE
revert to hardcoding db name to try to fix deploy

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: "jdbc:postgresql://${nldiDbHost}:${nldiDbPort}/${nldiDbName}"
+    url: "jdbc:postgresql://${nldiDbHost}:${nldiDbPort}/nldi"
     username: ${nldiDbUsername}
     password: ${nldiDbPassword}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Revert to hardcoding db name
-----------
PR #147 removed hardcoding of db name, but deploy is failing because "nldi_db_name" cannot be found.  Originally the db name was hardcoded as nldi, so revert to that to get deploy working, and then investigate why app doesn't react correctly to variables set in nldi-services.yml

Description
-----------

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
