### PR TITLE
Implement HTML media type for NLDI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 *   Add code coverage
 *   Migrate from springfox to springdoc
 *   Added swagger annotations
+*   Implement HTML media type for NLDI resources
   
 ## [1.2.0](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.1.0...nldi-services-1.2.0)
 ### Changed

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 ignore:
   # Spring Boot Application file - no testable logic
   - "**/Application.java"
+
+  # OpenAPI model classes - no testable logic
+  - "gov/usgs/owi/nldi/swagger/model"

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,4 +3,4 @@ ignore:
   - "**/Application.java"
 
   # OpenAPI model classes - no testable logic
-  - "gov/usgs/owi/nldi/swagger/model"
+  - "**/swagger/model/*.java"

--- a/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
@@ -1,13 +1,20 @@
 package gov.usgs.owi.nldi.controllers;
 
+import java.io.IOException;
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Pattern;
 
 import org.apache.ibatis.session.ResultHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
@@ -27,6 +34,8 @@ import gov.usgs.owi.nldi.transform.BasinTransformer;
 import gov.usgs.owi.nldi.transform.FeatureTransformer;
 import gov.usgs.owi.nldi.transform.FlowLineTransformer;
 import gov.usgs.owi.nldi.transform.ITransformer;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Validated
 public abstract class BaseController {
@@ -35,8 +44,8 @@ public abstract class BaseController {
 	public static final String HEADER_CONTENT_TYPE = "Content-Type";
 	public static final String MIME_TYPE_GEOJSON = "application/vnd.geo+json";
 	public static final String REGEX_NAVIGATION_MODE = "DD|DM|PP|UT|UM";
-
-	static final String DATA_SOURCE = "dataSource";
+    	public static final String OUTPUT_FORMAT = "json|html";
+	public static final String DATA_SOURCE = "dataSource";
 
 	protected final LookupDao lookupDao;
 	protected final StreamingDao streamingDao;
@@ -55,6 +64,7 @@ public abstract class BaseController {
 		configurationService = inConfigurationService;
 		logService = inLogService;
 	}
+
 
 	protected void streamFlowLines(HttpServletResponse response,
 			String comid, String navigationMode, String stopComid, String distance, boolean legacy) throws Exception {

--- a/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
@@ -1,20 +1,13 @@
 package gov.usgs.owi.nldi.controllers;
 
-import java.io.IOException;
-import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.Pattern;
 
 import org.apache.ibatis.session.ResultHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.MediaType;
-import org.springframework.util.FileCopyUtils;
 import org.springframework.util.NumberUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
@@ -34,8 +27,6 @@ import gov.usgs.owi.nldi.transform.BasinTransformer;
 import gov.usgs.owi.nldi.transform.FeatureTransformer;
 import gov.usgs.owi.nldi.transform.FlowLineTransformer;
 import gov.usgs.owi.nldi.transform.ITransformer;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @Validated
 public abstract class BaseController {

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -1,0 +1,58 @@
+package gov.usgs.owi.nldi.controllers;
+
+import gov.usgs.owi.nldi.services.LogService;
+import gov.usgs.owi.nldi.services.Parameters;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Pattern;
+import java.io.IOException;
+import java.math.BigInteger;
+
+@RestController
+public class HtmlController {
+
+	@Autowired
+	LogService logService;
+
+	@GetMapping(value="/linked-data/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
+	public String getLinkedDataHtml(HttpServletRequest request, HttpServletResponse response,
+									@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		return processHtml(request, response);
+	}
+
+	@GetMapping(value="/linked-data/comid/**", produces= MediaType.TEXT_HTML_VALUE)
+	public String getNetworkHtml(HttpServletRequest request, HttpServletResponse response,
+								 @RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		return processHtml(request, response);
+	}
+
+	@GetMapping(value="/lookups/**", produces= MediaType.TEXT_HTML_VALUE)
+	public String getLookupsHtml(HttpServletRequest request, HttpServletResponse response,
+								 @RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		return processHtml(request, response);
+	}
+
+	private String getHtmlString(HttpServletRequest request) throws IOException {
+		StringBuffer url = request.getRequestURL();
+		url.append("?f=json");
+		String html = new String(FileCopyUtils.copyToByteArray(new ClassPathResource("/html/htmlresponse.html").getInputStream()));
+		return html.replace("URL_MARKER", url);
+	}
+
+	private String processHtml(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		BigInteger logId = logService.logRequest(request);
+		try {
+			return getHtmlString(request);
+		} finally {
+			logService.logRequestComplete(logId, response.getStatus());
+		}
+	}
+}

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -24,19 +24,22 @@ public class HtmlController {
 
 	@GetMapping(value="/linked-data/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getLinkedDataHtml(HttpServletRequest request, HttpServletResponse response,
-									@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/linked-data/comid/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getNetworkHtml(HttpServletRequest request, HttpServletResponse response,
-								 @RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/lookups/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getLookupsHtml(HttpServletRequest request, HttpServletResponse response,
-								 @RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
+		
 		return processHtml(request, response);
 	}
 

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -20,7 +20,7 @@ import java.math.BigInteger;
 public class HtmlController {
 
 	@Autowired
-	LogService logService;
+	private LogService logService;
 
 	@GetMapping(value="/linked-data/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getLinkedDataHtml(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
@@ -62,15 +62,12 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data endpoint
 	@Operation(summary = "getDataSources", description = "returns a list of data sources")
-	
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK",
 					content = { @Content(mediaType = "application/json",
 							schema = @Schema(implementation = DataSource.class)) }),
 			@ApiResponse(responseCode = "500", description = "Server error",
 					content = @Content) })
-
-
 	@GetMapping(value="linked-data", produces=MediaType.APPLICATION_JSON_VALUE)
 	public List<Map<String, Object>> getDataSources(HttpServletRequest request, HttpServletResponse response) {
 		BigInteger logId = logService.logRequest(request);
@@ -98,14 +95,12 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource} endpoint
 	@Operation(summary = "getFeatures", description = "returns a list of features for a given data source")
-	
 	@ApiResponses(value = {
 			@ApiResponse(responseCode = "200", description = "OK",
 					content = { @Content(mediaType = "application/json",
 							schema = @Schema(implementation = Feature.class)) }),
 			@ApiResponse(responseCode = "500", description = "Server error",
 					content = @Content) })
-
 	@GetMapping(value="linked-data/{featureSource}", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getFeatures(HttpServletRequest request, HttpServletResponse response,
 							@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource) {
@@ -128,7 +123,6 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID} endpoint
 	@Operation(summary = "getRegisteredFeature", description = "returns registered feature as WGS84 lat/lon GeoJSON if it exists")
-	
 	@GetMapping(value="linked-data/{featureSource}/{featureID}", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getRegisteredFeature(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
@@ -149,7 +143,6 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate endpoint
 	@Operation(summary = "getNavigationTypes", description = "returns valid navigation end points")
-	
 	@GetMapping(value="linked-data/{featureSource}/{featureID}/navigate", produces=MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> getNavigationTypes(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
@@ -186,8 +179,7 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/{characteristicType} endpoint
 	@Operation(summary = "getCharacteristicData", description = "returns all characteristics of the given type for the specified feature")
-	
-	@GetMapping(value="linked-data/{featureSource}/{featureID}/{characteristicType}")
+	@GetMapping(value="linked-data/{featureSource}/{featureID}/{characteristicType}", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getCharacteristicData(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
 			@PathVariable(Parameters.FEATURE_ID) String featureID,
@@ -218,8 +210,7 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/basin endpoint
 	@Operation(summary = "getBasin", description = "returns the aggregated basin for the specified feature in WGS84 lat/lon GeoJSON")
-	
-	@GetMapping(value="linked-data/{featureSource}/{featureID}/basin")
+	@GetMapping(value="linked-data/{featureSource}/{featureID}/basin", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getBasin(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
 			@PathVariable(Parameters.FEATURE_ID) String featureID) throws Exception {
@@ -243,7 +234,6 @@ public class LinkedDataController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
 	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
-	
 	@GetMapping(value="linked-data/{featureSource}/{featureID}/navigate/{navigationMode}", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
@@ -301,6 +291,4 @@ public class LinkedDataController extends BaseController {
 			logService.logRequestComplete(logId, response.getStatus());
 		}
 	}
-
-
 }

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LookupController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LookupController.java
@@ -6,11 +6,14 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Pattern;
 
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import gov.usgs.owi.nldi.dao.BaseDao;
@@ -34,8 +37,7 @@ public class LookupController extends BaseController {
 
 	//swagger documentation for /lookups/{characteristicType}/characteristics endpoint
 	@Operation(summary = "getCharacteristics", description = "Returns available characteristics metadata")
-
-	@GetMapping(value="lookups/{characteristicType}/characteristics")
+	@GetMapping(value="lookups/{characteristicType}/characteristics",produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getCharacteristics(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(Parameters.CHARACTERISTIC_TYPE) String characteristicType) throws Exception {
 		BigInteger logId = logService.logRequest(request);

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LookupController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LookupController.java
@@ -6,14 +6,12 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.Pattern;
 
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import gov.usgs.owi.nldi.dao.BaseDao;

--- a/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,8 +37,7 @@ public class NetworkController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
 	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
-	
-	@GetMapping
+	@GetMapping(produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(Parameters.COMID) @Range(min=1, max=Integer.MAX_VALUE) String comid,
 			@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
@@ -58,8 +58,7 @@ public class NetworkController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode}/{dataSource} endpoint
 	@Operation(summary = "getFeatures", description = "Returns all features found along the specified navigation as points in WGS84 lat/lon GeoJSON")
-	
-	@GetMapping(value="{dataSource}")
+	@GetMapping(value="{dataSource}", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getFeatures(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(Parameters.COMID) @Range(min=1, max=Integer.MAX_VALUE) String comid,
 			@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
@@ -71,7 +70,6 @@ public class NetworkController extends BaseController {
 			@RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
 		BigInteger logId = logService.logRequest(request);
 		try {
-
 			streamFeatures(response, comid, navigationMode, stopComid, distance, dataSource, isLegacy(legacy, navigationMode));
 		} catch (Exception e) {
 			GlobalDefaultExceptionHandler.handleError(e, response);

--- a/src/main/java/gov/usgs/owi/nldi/services/Parameters.java
+++ b/src/main/java/gov/usgs/owi/nldi/services/Parameters.java
@@ -24,6 +24,7 @@ public class Parameters {
 	public static final String NAVIGATION_MODE = "navigationMode";
 	public static final String STOP_COMID = "stopComid";
 	public static final String LEGACY = "legacy";
+	public static final String FORMAT = "f";
 	public static final String CHARACTERISTIC_TYPE = "characteristicType";
 	public static final String CHARACTERISTIC_ID = "characteristicId";
 	public static final String DISTANCE_VALIDATION_MESSAGE = "distance must be between 1 and 9999 kilometers";

--- a/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
@@ -2,13 +2,25 @@ package gov.usgs.owi.nldi.springinit;
 
 import javax.sql.DataSource;
 
+import gov.usgs.owi.nldi.services.Parameters;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.accept.ContentNegotiationStrategy;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @Configuration
 public class SpringConfig implements WebMvcConfigurer {
@@ -30,12 +42,43 @@ public class SpringConfig implements WebMvcConfigurer {
 	}
 
 	@Override
+	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+		configurer.strategies(Arrays.asList(new ContentNegotiationStrategy() {
+					@Override
+					public List<MediaType> resolveMediaTypes(NativeWebRequest webRequest)
+							throws HttpMediaTypeNotAcceptableException {
+						//If the user specifies output with the format parameter, give them what they asked for.
+						Map<String, String[]> map = webRequest.getParameterMap();
+                        if (map != null) {
+                        	String[] values = map.get(Parameters.FORMAT);
+                        	if (values != null) {
+                        		if (values[0].toLowerCase().equals("json")) {
+                        			return Arrays.asList(MediaType.APPLICATION_JSON);
+								} else if (values[0].toLowerCase().equals("html")) {
+                        			return Arrays.asList(MediaType.TEXT_HTML);
+								}
+							}
+						}
+                        //Browsers have 'text/html' as the first element in their accept headers,
+						// so if it is the first element, the user has stumbled to this url in the
+						// browser and may not expect a json dump.
+						String accept = webRequest.getHeader(HttpHeaders.ACCEPT);
+						if (accept != null && accept.startsWith(MediaType.TEXT_HTML_VALUE)) {
+							return Arrays.asList(MediaType.TEXT_HTML);
+						} else {
+							return Arrays.asList(MediaType.APPLICATION_JSON);
+						}
+					}
+				}));
+	}
+
+	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry
-			.addMapping("/**")
-			.allowedOrigins("*")
-			.allowedMethods("GET", "OPTIONS")
-			.allowedHeaders("Origin", "Accept", "X-Requested-With", "Content-Type", "Access-Control-Request-Method", "Access-Control-Request-Headers")
-			.exposedHeaders("feature_count", "flowLine_count");
+				.addMapping("/**")
+				.allowedOrigins("*")
+				.allowedMethods("GET", "OPTIONS")
+				.allowedHeaders("Origin", "Accept", "X-Requested-With", "Content-Type", "Access-Control-Request-Method", "Access-Control-Request-Headers")
+				.exposedHeaders("feature_count", "flowLine_count");
 	}
 }

--- a/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
@@ -49,28 +49,28 @@ public class SpringConfig implements WebMvcConfigurer {
 						
 				//If the user specifies output with the format parameter, give them what they asked for.
 				Map<String, String[]> map = webRequest.getParameterMap();
-                        	if (map != null) {
-                        		String[] values = map.get(Parameters.FORMAT);
-                        		if (values != null) {
-                        			if (values[0].toLowerCase().equals("json")) {
-                        				return Arrays.asList(MediaType.APPLICATION_JSON);
-								} else if (values[0].toLowerCase().equals("html")) {
-                        				return Arrays.asList(MediaType.TEXT_HTML);
-								}
-							}
-						}
-
-                        		//Browsers have 'text/html' as the first element in their accept headers,
-					// so if it is the first element, the user has stumbled to this url in the
-					// browser and may not expect a json dump.
-					String accept = webRequest.getHeader(HttpHeaders.ACCEPT);
-					if (accept != null && accept.startsWith(MediaType.TEXT_HTML_VALUE)) {
-						return Arrays.asList(MediaType.TEXT_HTML);
-					} else {
-						return Arrays.asList(MediaType.APPLICATION_JSON);
+				if (map != null) {
+					String[] values = map.get(Parameters.FORMAT);
+					if (values != null) {
+						if (values[0].toLowerCase().equals("json")) {
+							return Arrays.asList(MediaType.APPLICATION_JSON);
+						} else if (values[0].toLowerCase().equals("html")) {
+							return Arrays.asList(MediaType.TEXT_HTML);
 						}
 					}
-				}));
+				}
+
+				//Browsers have 'text/html' as the first element in their accept headers,
+				// so if it is the first element, the user has stumbled to this url in the
+				// browser and may not expect a json dump.
+				String accept = webRequest.getHeader(HttpHeaders.ACCEPT);
+				if (accept != null && accept.startsWith(MediaType.TEXT_HTML_VALUE)) {
+					return Arrays.asList(MediaType.TEXT_HTML);
+				} else {
+					return Arrays.asList(MediaType.APPLICATION_JSON);
+				}
+			}
+		}));
 	}
 
 	@Override

--- a/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
@@ -17,7 +17,6 @@ import org.springframework.web.servlet.config.annotation.DefaultServletHandlerCo
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/SpringConfig.java
@@ -43,29 +43,31 @@ public class SpringConfig implements WebMvcConfigurer {
 	@Override
 	public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
 		configurer.strategies(Arrays.asList(new ContentNegotiationStrategy() {
-					@Override
-					public List<MediaType> resolveMediaTypes(NativeWebRequest webRequest)
-							throws HttpMediaTypeNotAcceptableException {
-						//If the user specifies output with the format parameter, give them what they asked for.
-						Map<String, String[]> map = webRequest.getParameterMap();
-                        if (map != null) {
-                        	String[] values = map.get(Parameters.FORMAT);
-                        	if (values != null) {
-                        		if (values[0].toLowerCase().equals("json")) {
-                        			return Arrays.asList(MediaType.APPLICATION_JSON);
+			@Override
+			public List<MediaType> resolveMediaTypes(NativeWebRequest webRequest)
+				throws HttpMediaTypeNotAcceptableException {
+						
+				//If the user specifies output with the format parameter, give them what they asked for.
+				Map<String, String[]> map = webRequest.getParameterMap();
+                        	if (map != null) {
+                        		String[] values = map.get(Parameters.FORMAT);
+                        		if (values != null) {
+                        			if (values[0].toLowerCase().equals("json")) {
+                        				return Arrays.asList(MediaType.APPLICATION_JSON);
 								} else if (values[0].toLowerCase().equals("html")) {
-                        			return Arrays.asList(MediaType.TEXT_HTML);
+                        				return Arrays.asList(MediaType.TEXT_HTML);
 								}
 							}
 						}
-                        //Browsers have 'text/html' as the first element in their accept headers,
-						// so if it is the first element, the user has stumbled to this url in the
-						// browser and may not expect a json dump.
-						String accept = webRequest.getHeader(HttpHeaders.ACCEPT);
-						if (accept != null && accept.startsWith(MediaType.TEXT_HTML_VALUE)) {
-							return Arrays.asList(MediaType.TEXT_HTML);
-						} else {
-							return Arrays.asList(MediaType.APPLICATION_JSON);
+
+                        		//Browsers have 'text/html' as the first element in their accept headers,
+					// so if it is the first element, the user has stumbled to this url in the
+					// browser and may not expect a json dump.
+					String accept = webRequest.getHeader(HttpHeaders.ACCEPT);
+					if (accept != null && accept.startsWith(MediaType.TEXT_HTML_VALUE)) {
+						return Arrays.asList(MediaType.TEXT_HTML);
+					} else {
+						return Arrays.asList(MediaType.APPLICATION_JSON);
 						}
 					}
 				}));
@@ -74,10 +76,10 @@ public class SpringConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry
-				.addMapping("/**")
-				.allowedOrigins("*")
-				.allowedMethods("GET", "OPTIONS")
-				.allowedHeaders("Origin", "Accept", "X-Requested-With", "Content-Type", "Access-Control-Request-Method", "Access-Control-Request-Headers")
-				.exposedHeaders("feature_count", "flowLine_count");
+			.addMapping("/**")
+			.allowedOrigins("*")
+			.allowedMethods("GET", "OPTIONS")
+			.allowedHeaders("Origin", "Accept", "X-Requested-With", "Content-Type", "Access-Control-Request-Method", "Access-Control-Request-Headers")
+			.exposedHeaders("feature_count", "flowLine_count");
 	}
 }

--- a/src/main/resources/html/htmlresponse.html
+++ b/src/main/resources/html/htmlresponse.html
@@ -1,0 +1,7 @@
+<html>
+
+An HTML representation is not available for this resource.
+<br/>
+If you would like to see the data as JSON, <a href="URL_MARKER">click here</a>.
+
+</html>

--- a/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
@@ -1,0 +1,97 @@
+package gov.usgs.owi.nldi.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import gov.usgs.owi.nldi.BaseIT;
+
+@EnableWebMvc
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
+@DatabaseSetup("classpath:/testData/crawlerSource.xml")
+public class HtmlControllerIT extends BaseIT {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@BeforeEach
+	public void setUp() {
+		urlRoot = "http://localhost:" + port + context;
+	}
+
+
+	@Test
+	public void getLinkedDataHtmlTest() throws Exception {
+		String actualbody = assertEntity(restTemplate,
+				"/linked-data/nwissite?f=html",
+				HttpStatus.OK.value(),
+				null,
+				null,
+				null,
+				null,
+				false,
+				false);
+
+		assertTrue(actualbody.contains("?f=json"));
+		assertTrue(actualbody.contains("/linked-data/nwissite"));
+		assertTrue(actualbody.contains("<html>"));
+		assertTrue(actualbody.contains("</html"));
+		assertTrue(actualbody.contains("<a "));
+		assertTrue(actualbody.contains("href="));
+		assertTrue(actualbody.contains("a>"));
+	}
+
+	@Test
+	public void getNetworkHtmlTest() throws Exception {
+		String actualbody = assertEntity(restTemplate,
+				"/linked-data/comid/13302592/tot?f=html",
+				HttpStatus.OK.value(),
+				null,
+				null,
+				null,
+				null,
+				false,
+				false);
+
+		assertTrue(actualbody.contains("?f=json"));
+		assertTrue(actualbody.contains("/linked-data/comid/13302592/tot"));
+		assertTrue(actualbody.contains("<html>"));
+		assertTrue(actualbody.contains("</html"));
+		assertTrue(actualbody.contains("<a "));
+		assertTrue(actualbody.contains("href="));
+		assertTrue(actualbody.contains("a>"));
+	}
+
+
+	@Test
+	public void getLookupsHtmlTest() throws Exception {
+		String actualbody = assertEntity(restTemplate,
+				"/lookups/x?f=html",
+				HttpStatus.OK.value(),
+				null,
+				null,
+				null,
+				null,
+				false,
+				false);
+		assertTrue(actualbody.contains("/lookups/x?f=json"));
+		assertTrue(actualbody.contains("<html>"));
+		assertTrue(actualbody.contains("</html"));
+		assertTrue(actualbody.contains("<a "));
+		assertTrue(actualbody.contains("href="));
+		assertTrue(actualbody.contains("a>"));
+	}
+}

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
@@ -1,6 +1,7 @@
 package gov.usgs.owi.nldi.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
 import org.json.JSONArray;

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
@@ -1,7 +1,6 @@
 package gov.usgs.owi.nldi.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
 import org.json.JSONArray;

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerTest.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerTest.java
@@ -163,6 +163,7 @@ public class LinkedDataControllerTest {
 		assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());
 	}
 
+
 	@Test
 	public void getBasinTest() throws Exception {
 		when(lookupDao.getComid(anyString(), anyMap())).thenReturn(goodFeature());


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Implement HTML media type for NLDI resources
-----------
Add an HTML controller which will handle requests that explicitly ask for html (?f=html) or where the user is clearly navigating in the browser ("text/html" first element in accept header).   The HTML controller will say that there is no HTML representation and provide a link the user can click on which will redirect to the same page with the "f=json" flag.

Description
-----------
https://internal.cida.usgs.gov/jira/browse/NHGF-9

This story was deferred and reactivated, so this pull request is a continuation of https://github.com/ACWI-SSWD/nldi-services/pull/146.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
