### PR TITLE
Modify default navigation response and version API (NLDI-50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 *   Migrate from springfox to springdoc
 *   Added swagger annotations
 *   Implement HTML media type for NLDI resources
+*   Add V2 for navigate endpoint
   
 ## [1.2.0](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.1.0...nldi-services-1.2.0)
 ### Changed

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -25,21 +25,25 @@ public class HtmlController {
 	@GetMapping(value="/linked-data/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getLinkedDataHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
-		
+		return processHtml(request, response);
+	}
+
+
+	@GetMapping(value="/linked-data/v2/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
+	public String getLinkedDataV2Html(HttpServletRequest request, HttpServletResponse response,
+									@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/linked-data/comid/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getNetworkHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
-		
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/lookups/**", produces= MediaType.TEXT_HTML_VALUE)
 	public String getLookupsHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
-		
 		return processHtml(request, response);
 	}
 

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
@@ -235,6 +235,7 @@ public class LinkedDataController extends BaseController {
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
 	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
 	@GetMapping(value="linked-data/{featureSource}/{featureID}/navigate/{navigationMode}", produces=MediaType.APPLICATION_JSON_VALUE)
+	@Deprecated
 	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
 			@PathVariable(Parameters.FEATURE_ID) String featureID,

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2.java
@@ -1,0 +1,147 @@
+package gov.usgs.owi.nldi.controllers;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.Pattern;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.util.NumberUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import gov.usgs.owi.nldi.NavigationMode;
+import gov.usgs.owi.nldi.dao.BaseDao;
+import gov.usgs.owi.nldi.dao.LookupDao;
+import gov.usgs.owi.nldi.dao.NavigationDao;
+import gov.usgs.owi.nldi.dao.StreamingDao;
+import gov.usgs.owi.nldi.services.ConfigurationService;
+import gov.usgs.owi.nldi.services.LogService;
+import gov.usgs.owi.nldi.services.Navigation;
+import gov.usgs.owi.nldi.services.Parameters;
+import gov.usgs.owi.nldi.swagger.model.DataSource;
+import gov.usgs.owi.nldi.swagger.model.Feature;
+import gov.usgs.owi.nldi.transform.CharacteristicDataTransformer;
+import gov.usgs.owi.nldi.transform.FeatureTransformer;
+import gov.usgs.owi.nldi.transform.FeatureCollectionTransformer;
+
+@RestController
+public class LinkedDataControllerV2 extends BaseController {
+
+	private static final String DOWNSTREAM_DIVERSIONS = "downstreamDiversions";
+	private static final String DOWNSTREAM_MAIN = "downstreamMain";
+	private static final String UPSTREAM_MAIN = "upstreamMain";
+	private static final String UPSTREAM_TRIBUTARIES = "upstreamTributaries";
+
+	@Autowired
+	LinkedDataController controllerV1;
+
+	@Autowired
+	public LinkedDataControllerV2(LookupDao inLookupDao, StreamingDao inStreamingDao,
+			Navigation inNavigation, Parameters inParameters, ConfigurationService configurationService,
+			LogService inLogService) {
+		super(inLookupDao, inStreamingDao, inNavigation, inParameters, configurationService, inLogService);
+	}
+
+	//swagger documentation for /linked-data/v2/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
+	@Operation(summary = "getNavigateOptions", description = "returns the navigation options for the specified navigation in WGS84 lat/lon GeoJSON")
+	@GetMapping(value="linked-data/v2/{featureSource}/{featureID}/navigate/{navigationMode}", produces=MediaType.APPLICATION_JSON_VALUE)
+	public List<Map<String, Object>> getNavigationOptions(
+		HttpServletRequest request, HttpServletResponse response,
+		@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
+		@PathVariable(Parameters.FEATURE_ID) String featureID,
+		@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
+		@RequestParam(value=Parameters.STOP_COMID, required=false) @Range(min=1, max=Integer.MAX_VALUE) String stopComid,
+		@Parameter(description=Parameters.DISTANCE_DESCRIPTION)
+		@RequestParam(value=Parameters.DISTANCE, required=false, defaultValue=Parameters.MAX_DISTANCE)
+		@Pattern(message=Parameters.DISTANCE_VALIDATION_MESSAGE, regexp=Parameters.DISTANCE_VALIDATION_REGEX) String distance,
+		@RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
+
+		BigInteger logId = logService.logRequest(request);
+
+		try {
+			List<Map<String, Object>> dataSources = controllerV1.getDataSources(request, response);
+			List<Map<String, Object>> newDataSources = new ArrayList<>();
+			String newNavigationUrl = createNewNavigationUrl(request);
+			for (Map<String, Object> dataSource: dataSources) {
+				if ("comid".equals(dataSource.get("source"))) {
+					dataSource.put("source", "Flowlines");
+					dataSource.put("sourceName", "NHDPlus flowlines");
+					String flowlinesV2Url = newNavigationUrl.replace("linked-data/", "linked-data/v2/");
+					dataSource.put("features", flowlinesV2Url  + "flowlines");
+					newDataSources.add(dataSource);
+				} else {
+					dataSource.put("features", newNavigationUrl
+						+ dataSource.get("source").toString().toLowerCase());
+					newDataSources.add(dataSource);
+				}
+			}
+			return newDataSources;
+
+		} catch (Exception e) {
+			GlobalDefaultExceptionHandler.handleError(e, response);
+		} finally {
+			logService.logRequestComplete(logId, response.getStatus());
+		}
+		return null;
+	}
+
+	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
+	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
+	@GetMapping(value="linked-data/v2/{featureSource}/{featureID}/navigate/{navigationMode}/flowlines", produces=MediaType.APPLICATION_JSON_VALUE)
+	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
+							 @PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
+							 @PathVariable(Parameters.FEATURE_ID) String featureID,
+							 @PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
+							 @RequestParam(value=Parameters.STOP_COMID, required=false) @Range(min=1, max=Integer.MAX_VALUE) String stopComid,
+							 @Parameter(description=Parameters.DISTANCE_DESCRIPTION)
+							 @RequestParam(value=Parameters.DISTANCE, required=false, defaultValue=Parameters.MAX_DISTANCE)
+							 @Pattern(message=Parameters.DISTANCE_VALIDATION_MESSAGE, regexp=Parameters.DISTANCE_VALIDATION_REGEX) String distance,
+							 @RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
+
+		BigInteger logId = logService.logRequest(request);
+
+		try {
+			controllerV1.getFlowlines(request, response, featureSource, featureID, navigationMode, stopComid, distance, legacy);
+		} catch (Exception e) {
+			GlobalDefaultExceptionHandler.handleError(e, response);
+		} finally {
+			logService.logRequestComplete(logId, response.getStatus());
+		}
+	}
+
+
+	// We need to create navigation urls for the various options (see test file navigate_V2.json)
+	// We do this by starting with the linked-data url from the configuration service
+	// then adding all the request-specific elements from the request we received
+	private String createNewNavigationUrl(HttpServletRequest request) {
+		String newUrl = configurationService.getLinkedDataUrl();
+		String requestUrl = request.getRequestURL().toString();
+		String[] arr = requestUrl.split("linked-data/v2");
+		newUrl += arr[1];
+		newUrl += "/";
+		return newUrl;
+	}
+
+
+}

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2.java
@@ -1,12 +1,7 @@
 package gov.usgs.owi.nldi.controllers;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import java.net.URLEncoder;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,45 +11,26 @@ import javax.validation.constraints.Pattern;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.util.NumberUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import gov.usgs.owi.nldi.NavigationMode;
-import gov.usgs.owi.nldi.dao.BaseDao;
 import gov.usgs.owi.nldi.dao.LookupDao;
-import gov.usgs.owi.nldi.dao.NavigationDao;
 import gov.usgs.owi.nldi.dao.StreamingDao;
 import gov.usgs.owi.nldi.services.ConfigurationService;
 import gov.usgs.owi.nldi.services.LogService;
 import gov.usgs.owi.nldi.services.Navigation;
 import gov.usgs.owi.nldi.services.Parameters;
-import gov.usgs.owi.nldi.swagger.model.DataSource;
-import gov.usgs.owi.nldi.swagger.model.Feature;
-import gov.usgs.owi.nldi.transform.CharacteristicDataTransformer;
-import gov.usgs.owi.nldi.transform.FeatureTransformer;
-import gov.usgs.owi.nldi.transform.FeatureCollectionTransformer;
 
 @RestController
 public class LinkedDataControllerV2 extends BaseController {
 
-	private static final String DOWNSTREAM_DIVERSIONS = "downstreamDiversions";
-	private static final String DOWNSTREAM_MAIN = "downstreamMain";
-	private static final String UPSTREAM_MAIN = "upstreamMain";
-	private static final String UPSTREAM_TRIBUTARIES = "upstreamTributaries";
-
 	@Autowired
-	LinkedDataController controllerV1;
+	private LinkedDataController controllerV1;
 
 	@Autowired
 	public LinkedDataControllerV2(LookupDao inLookupDao, StreamingDao inStreamingDao,
@@ -109,15 +85,16 @@ public class LinkedDataControllerV2 extends BaseController {
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
 	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
 	@GetMapping(value="linked-data/v2/{featureSource}/{featureID}/navigate/{navigationMode}/flowlines", produces=MediaType.APPLICATION_JSON_VALUE)
-	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
-							 @PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
-							 @PathVariable(Parameters.FEATURE_ID) String featureID,
-							 @PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
-							 @RequestParam(value=Parameters.STOP_COMID, required=false) @Range(min=1, max=Integer.MAX_VALUE) String stopComid,
-							 @Parameter(description=Parameters.DISTANCE_DESCRIPTION)
-							 @RequestParam(value=Parameters.DISTANCE, required=false, defaultValue=Parameters.MAX_DISTANCE)
-							 @Pattern(message=Parameters.DISTANCE_VALIDATION_MESSAGE, regexp=Parameters.DISTANCE_VALIDATION_REGEX) String distance,
-							 @RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
+	public void getFlowlines(
+		HttpServletRequest request, HttpServletResponse response,
+		@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
+		@PathVariable(Parameters.FEATURE_ID) String featureID,
+		@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
+		@RequestParam(value=Parameters.STOP_COMID, required=false) @Range(min=1, max=Integer.MAX_VALUE) String stopComid,
+		@Parameter(description=Parameters.DISTANCE_DESCRIPTION)
+		@RequestParam(value=Parameters.DISTANCE, required=false, defaultValue=Parameters.MAX_DISTANCE)
+		@Pattern(message=Parameters.DISTANCE_VALIDATION_MESSAGE, regexp=Parameters.DISTANCE_VALIDATION_REGEX) String distance,
+		@RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
 
 		BigInteger logId = logService.logRequest(request);
 

--- a/src/main/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2.java
@@ -1,15 +1,10 @@
 package gov.usgs.owi.nldi.controllers;
 
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Pattern;
-
-import gov.usgs.owi.nldi.dao.BaseDao;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.hibernate.validator.constraints.Range;
@@ -53,28 +48,6 @@ public class NetworkControllerV2 extends BaseController {
 		BigInteger logId = logService.logRequest(request);
 		try {
 			streamFlowLines(response, comid, navigationMode, stopComid, distance, isLegacy(legacy, navigationMode));
-		} catch (Exception e) {
-			GlobalDefaultExceptionHandler.handleError(e, response);
-		} finally {
-			logService.logRequestComplete(logId, response.getStatus());
-		}
-	}
-
-	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode}/{dataSource} endpoint
-	@Operation(summary = "getFeatures", description = "Returns all features found along the specified navigation as points in WGS84 lat/lon GeoJSON")
-	@GetMapping(value="{dataSource}", produces=MediaType.APPLICATION_JSON_VALUE)
-	public void getFeatures(HttpServletRequest request, HttpServletResponse response,
-			@PathVariable(Parameters.COMID) @Range(min=1, max=Integer.MAX_VALUE) String comid,
-			@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,
-			@PathVariable(value=DATA_SOURCE) String dataSource,
-			@RequestParam(value=Parameters.STOP_COMID, required=false) @Range(min=1, max=Integer.MAX_VALUE) String stopComid,
-			@Parameter(description=Parameters.DISTANCE_DESCRIPTION)
-				@RequestParam(value=Parameters.DISTANCE, required=false, defaultValue=Parameters.MAX_DISTANCE)
-			@Pattern(message=Parameters.DISTANCE_VALIDATION_MESSAGE, regexp=Parameters.DISTANCE_VALIDATION_REGEX) String distance,
-			@RequestParam(value=Parameters.LEGACY, required=false) String legacy) throws Exception {
-		BigInteger logId = logService.logRequest(request);
-		try {
-			streamFeatures(response, comid, navigationMode, stopComid, distance, dataSource, isLegacy(legacy, navigationMode));
 		} catch (Exception e) {
 			GlobalDefaultExceptionHandler.handleError(e, response);
 		} finally {

--- a/src/main/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2.java
@@ -1,11 +1,15 @@
 package gov.usgs.owi.nldi.controllers;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.Pattern;
 
+import gov.usgs.owi.nldi.dao.BaseDao;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.hibernate.validator.constraints.Range;
@@ -25,11 +29,11 @@ import gov.usgs.owi.nldi.services.Navigation;
 import gov.usgs.owi.nldi.services.Parameters;
 
 @RestController
-@RequestMapping(value="linked-data/comid/{comid}/navigate/{navigationMode}")
-public class NetworkController extends BaseController {
+@RequestMapping(value="linked-data/v2/comid/{comid}/navigate/{navigationMode}")
+public class NetworkControllerV2 extends BaseController {
 
 	@Autowired
-	public NetworkController(LookupDao inLookupDao, StreamingDao inStreamingDao,
+	public NetworkControllerV2(LookupDao inLookupDao, StreamingDao inStreamingDao,
 			Navigation inNavigation, Parameters inParameters, ConfigurationService configurationService,
 			LogService inLogService) {
 		super(inLookupDao, inStreamingDao, inNavigation, inParameters, configurationService, inLogService);
@@ -37,8 +41,7 @@ public class NetworkController extends BaseController {
 
 	//swagger documentation for /linked-data/{featureSource}/{featureID}/navigate/{navigationMode} endpoint
 	@Operation(summary = "getFlowlines", description = "returns the flowlines for the specified navigation in WGS84 lat/lon GeoJSON")
-	@GetMapping(produces=MediaType.APPLICATION_JSON_VALUE)
-	@Deprecated
+	@GetMapping(value="/flowlines", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getFlowlines(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(Parameters.COMID) @Range(min=1, max=Integer.MAX_VALUE) String comid,
 			@PathVariable(Parameters.NAVIGATION_MODE) @Pattern(regexp=REGEX_NAVIGATION_MODE) String navigationMode,

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
@@ -1,7 +1,6 @@
 package gov.usgs.owi.nldi.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
 import org.json.JSONArray;

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerOtherIT.java
@@ -1,6 +1,7 @@
 package gov.usgs.owi.nldi.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
 import org.json.JSONArray;
@@ -227,4 +228,5 @@ public class LinkedDataControllerOtherIT extends BaseIT {
 				true,
 				false);
 	}
+
 }

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
@@ -1,7 +1,6 @@
 package gov.usgs.owi.nldi.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
 import org.json.JSONArray;
@@ -19,7 +18,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import gov.usgs.owi.nldi.BaseIT;
-import gov.usgs.owi.nldi.transform.BasinTransformer;
 
 @EnableWebMvc
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
@@ -3,6 +3,7 @@ package gov.usgs.owi.nldi.controllers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
 
+import gov.usgs.owi.nldi.transform.FlowLineTransformer;
 import org.json.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ public class LinkedDataControllerV2IT extends BaseIT {
 	private TestRestTemplate restTemplate;
 
 	private static final String RESULT_FOLDER  = "feature/flowline/";
+	private static final String RESULT_FOLDER_WQP  = "feature/flowline/wqp/";
 
 	@BeforeEach
 	public void setUp() {
@@ -54,5 +56,37 @@ public class LinkedDataControllerV2IT extends BaseIT {
 		assertThat(new JSONArray(actualbody),
 			sameJSONArrayAs(new JSONArray(getCompareFile(RESULT_FOLDER, "navigate_V2.json"))).allowingAnyArrayOrdering());
 
+	}
+
+	@Test
+	@DatabaseSetup("classpath:/testData/featureWqp.xml")
+	public void getNavigationOptionsTestBadRequest() throws Exception {
+		String actualbody = assertEntity(restTemplate,
+			"/linked-data/v2/wqp/USGS-05427880/navigate/XX",
+			HttpStatus.BAD_REQUEST.value(),
+			null,
+			null,
+			null,
+			null,
+			false,
+			false);
+
+	}
+
+
+	//Flowlines
+
+	@Test
+	@DatabaseSetup("classpath:/testData/featureWqp.xml")
+	public void getWqpUMTest() throws Exception {
+		assertEntity(restTemplate,
+			"/linked-data/v2/wqp/USGS-05427880/navigate/UM/flowlines",
+			HttpStatus.OK.value(),
+			FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+			"10",
+			BaseController.MIME_TYPE_GEOJSON,
+			getCompareFile(RESULT_FOLDER_WQP, "wqp_USGS-05427880_UM.json"),
+			true,
+			false);
 	}
 }

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
@@ -61,7 +61,7 @@ public class LinkedDataControllerV2IT extends BaseIT {
 	@Test
 	@DatabaseSetup("classpath:/testData/featureWqp.xml")
 	public void getNavigationOptionsTestBadRequest() throws Exception {
-		String actualbody = assertEntity(restTemplate,
+		assertEntity(restTemplate,
 			"/linked-data/v2/wqp/USGS-05427880/navigate/XX",
 			HttpStatus.BAD_REQUEST.value(),
 			null,

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerV2IT.java
@@ -1,0 +1,60 @@
+package gov.usgs.owi.nldi.controllers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONArrayAs;
+
+import org.json.JSONArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import gov.usgs.owi.nldi.BaseIT;
+import gov.usgs.owi.nldi.transform.BasinTransformer;
+
+@EnableWebMvc
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
+@DatabaseSetup("classpath:/testData/crawlerSource.xml")
+public class LinkedDataControllerV2IT extends BaseIT {
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	private static final String RESULT_FOLDER  = "feature/flowline/";
+
+	@BeforeEach
+	public void setUp() {
+		urlRoot = "http://localhost:" + port + context;
+	}
+
+
+	//Navigation Types Testing
+	@Test
+	@DatabaseSetup("classpath:/testData/featureWqp.xml")
+	public void getNavigationOptionsTest() throws Exception {
+		String actualbody = assertEntity(restTemplate,
+			"/linked-data/v2/wqp/USGS-05427880/navigate/UT",
+			HttpStatus.OK.value(),
+			null,
+			null,
+			MediaType.APPLICATION_JSON_VALUE,
+			null,
+			true,
+			false);
+		assertThat(new JSONArray(actualbody),
+			sameJSONArrayAs(new JSONArray(getCompareFile(RESULT_FOLDER, "navigate_V2.json"))).allowingAnyArrayOrdering());
+
+	}
+}

--- a/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2FlowlineIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerV2FlowlineIT.java
@@ -1,0 +1,324 @@
+package gov.usgs.owi.nldi.controllers;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import gov.usgs.owi.nldi.BaseIT;
+import gov.usgs.owi.nldi.transform.FlowLineTransformer;
+
+
+@EnableWebMvc
+@SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
+@DatabaseSetup("classpath:/testData/crawlerSource.xml")
+public class NetworkControllerV2FlowlineIT extends BaseIT {
+
+	@Value("${serverContextPath}")
+	private String context;
+
+	@LocalServerPort
+	private int port;
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	private static final String RESULT_FOLDER  = "network/flowline/";
+
+	@BeforeEach
+	public void setUp() {
+		urlRoot = "http://localhost:" + port + context;
+	}
+
+	//UT Testing
+	@Test
+	public void getComidUtTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13293474/navigate/UT/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"7",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13293474_UT.json"),
+				true,
+				false);
+	}
+
+	@Test
+	public void getComidUtDistanceTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/UT/flowlines?distance=10",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"9",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13297246_UT_distance_10.json"),
+				true,
+				false);
+	}
+
+
+	@Test
+	public void getComidUtDistanceTestEmpty() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/UT/flowlines?distance=",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"359",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13297246_UT_distance_empty.json"),
+				true,
+				false);
+
+	}
+
+	@Test
+	public void getComidUtDistanceTestAboveMax() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/UT/flowlines?distance=10000",
+				HttpStatus.BAD_REQUEST.value(),
+				null,
+				null,
+				null,
+				"getFlowlines.distance: distance must be between 1 and 9999 kilometers",
+				false,
+				false);
+	}
+
+	@Test
+	public void getComidUtDistanceTestBelowMin() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/UT/flowlines?distance=-1",
+				HttpStatus.BAD_REQUEST.value(),
+				null,
+				null,
+				null,
+				"getFlowlines.distance: distance must be between 1 and 9999 kilometers",
+				false,
+				false);
+	}
+
+	@Test
+	public void getComidUtDiversionTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294158/navigate/UT/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"15",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294158_UT.json"),
+				true,
+				false);
+	}
+
+	//UM Testing
+	@Test
+	public void getComidUmTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13293474/navigate/UM/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"4",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13293474_UM.json"),
+				true,
+				false);
+	}
+
+	@Test
+	public void getComidUmDistanceTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/UM/flowlines?distance=10",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"6",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13297246_UM_distance_10.json"),
+				true,
+				false);
+	}
+
+	//DM Testing
+	@Test
+	public void getComidDmTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13296790/navigate/DM/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"5",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13296790_DM.json"),
+				true,
+				false);
+	}
+
+	@Test
+	public void getComidDmDiversionsNotIncludedTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294310/navigate/DM/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"42",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294310_DM.json"),
+				true,
+				false);
+	}
+
+	@Test
+	public void getComidDmDistanceTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13293474/navigate/DM/flowlines?distance=10",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"8",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13293474_DM_distance_10.json"),
+				true,
+				false);
+	}
+
+	//DD Testing
+	@Test
+	public void getComidDdTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294310/navigate/DD/flowlines",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"49",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294310_DD.json"),
+				true,
+				false);
+	}
+
+	@Test
+	public void getComidDdDistanceTest() throws Exception {
+		//We are going to sacrifice a little accuracy for performance, so this does not match the old way...
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294310/navigate/DD/flowlines?distance=11",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"13",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294310_DD_distance_11.json"),
+				true,
+				false);
+	}
+
+	//PP Testing
+	@Test
+	public void getComidPpStopComidInvalidTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297246/navigate/PP/flowlines?stopComid=13297198",
+				HttpStatus.BAD_REQUEST.value(),
+				null,
+				null,
+				MediaType.APPLICATION_JSON_VALUE,
+				getCompareFile(RESULT_FOLDER, "comid_13297246_PP_stop_13297198_v2.json"),
+				true,
+				true);
+	}
+
+	@Test
+	public void getComidPpStopComidTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297198/navigate/PP/flowlines?stopComid=13297246",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"12",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13297198_PP_stop_13297246.json"),
+				true,
+				false);
+	}
+
+	//Interesting diversion/tributary
+	//There is another simple diversion between 13294248 and 13294242
+	@Test
+	public void interestingTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13293844/navigate/DM/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"7",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13293844_DM_distance_5.json"),
+				true,
+				false);
+
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13293844/navigate/DD/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"14",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13293844_DD_distance_5.json"),
+				true,
+				false);
+
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294328/navigate/DM/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"6",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294328_DM_distance_5.json"),
+				true,
+				false);
+
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294328/navigate/DD/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"10",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294328_DD_distance_5.json"),
+				true,
+				false);
+
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294390/navigate/UM/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"6",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294390_UM_distance_5.json"),
+				true,
+				false);
+
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13294390/navigate/UT/flowlines?distance=5",
+				HttpStatus.OK.value(),
+				FlowLineTransformer.FLOW_LINES_COUNT_HEADER,
+				"22",
+				BaseController.MIME_TYPE_GEOJSON,
+				getCompareFile(RESULT_FOLDER, "comid_13294390_UT_distance_5.json"),
+				true,
+				false);
+	}
+
+	//Parameter Error Testing
+	@Test
+	public void badNavigationModeTest() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/v2/comid/13297198/navigate/XX/flowlines",
+				HttpStatus.BAD_REQUEST.value(),
+				null,
+				null,
+				null,
+				"getFlowlines.navigationMode: must match \"DD|DM|PP|UT|UM\"",
+				false,
+				false);
+	}
+
+}

--- a/src/test/resources/testResult/feature/flowline/navigate_V2.json
+++ b/src/test/resources/testResult/feature/flowline/navigate_V2.json
@@ -1,0 +1,21 @@
+[{
+	"source": "Flowlines",
+	"sourceName": "NHDPlus flowlines",
+	"features": "http://owi-test.usgs.gov:8080/test-url/linked-data/v2/wqp/USGS-05427880/navigate/UT/flowlines"
+}, {
+	"source": "huc12pp",
+	"sourceName": "huc12pp",
+	"features": "http://owi-test.usgs.gov:8080/test-url/linked-data/wqp/USGS-05427880/navigate/UT/huc12pp"
+}, {
+	"source": "np21_nwis",
+	"sourceName": "HNDPlusV2_NWIS_Gages",
+	"features": "http://owi-test.usgs.gov:8080/test-url/linked-data/wqp/USGS-05427880/navigate/UT/np21_nwis"
+}, {
+	"source": "TEST",
+	"sourceName": "TEST Source",
+	"features": "http://owi-test.usgs.gov:8080/test-url/linked-data/wqp/USGS-05427880/navigate/UT/test"
+}, {
+	"source": "WQP",
+	"sourceName": "Water Quality Portal",
+	"features": "http://owi-test.usgs.gov:8080/test-url/linked-data/wqp/USGS-05427880/navigate/UT/wqp"
+}]

--- a/src/test/resources/testResult/network/flowline/comid_13297246_PP_stop_13297198_v2.json
+++ b/src/test/resources/testResult/network/flowline/comid_13297246_PP_stop_13297198_v2.json
@@ -1,0 +1,6 @@
+{
+	"status": 400,
+	"error": "Bad Request",
+	"message": "{\"errorCode\":310, \"errorMessage\":\"Start ComID must have a hydroseq greater than the hydroseq for stop ComID.\"}",
+	"path": "/nldi/linked-data/v2/comid/13297246/navigate/PP/flowlines"
+}


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Modify default navigation response and version API.
-----------
1. Change the .../navigate/mode endpoint so that instead of returning flowlines by default, it returns a set of options including flowlines, but also navigation by the different data sources.
2. Create a version 2 of the LinkedDataController and a version 2 of the "navigate/mode" endpoint as well as the new "navigate/mode/flowlines" endpoint.

Description
-----------
https://github.com/ACWI-SSWD/nldi-services/issues/50

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
