### PR TITLE
trivial change to remove HtmlController from swagger

### DIFF
--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -2,6 +2,7 @@ package gov.usgs.owi.nldi.controllers;
 
 import gov.usgs.owi.nldi.services.LogService;
 import gov.usgs.owi.nldi.services.Parameters;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -23,6 +24,7 @@ public class HtmlController {
 	private LogService logService;
 
 	@GetMapping(value="/linked-data/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
+	@Hidden
 	public String getLinkedDataHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
 		return processHtml(request, response);
@@ -30,18 +32,21 @@ public class HtmlController {
 
 
 	@GetMapping(value="/linked-data/v2/{featureSource}/**", produces= MediaType.TEXT_HTML_VALUE)
+	@Hidden
 	public String getLinkedDataV2Html(HttpServletRequest request, HttpServletResponse response,
 									@RequestParam(name= Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/linked-data/comid/**", produces= MediaType.TEXT_HTML_VALUE)
+	@Hidden
 	public String getNetworkHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
 		return processHtml(request, response);
 	}
 
 	@GetMapping(value="/lookups/**", produces= MediaType.TEXT_HTML_VALUE)
+	@Hidden
 	public String getLookupsHtml(HttpServletRequest request, HttpServletResponse response,
 		@RequestParam(name=Parameters.FORMAT, required=false) @Pattern(regexp=BaseController.OUTPUT_FORMAT) String format) throws Exception {
 		return processHtml(request, response);


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Trivial change to remove HtmlController from Swagger
-----------
Add the @Hidden annotation so that HtmlController methods don't appear in Swagger.  They are not meant to be directed invoked by the end user.

Description
-----------


After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
