### PR TITLE
fix query so it uses the index on the_geom (NHGF 23)

### DIFF
--- a/src/main/java/gov/usgs/owi/nldi/controllers/GlobalDefaultExceptionHandler.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/GlobalDefaultExceptionHandler.java
@@ -1,10 +1,5 @@
 package gov.usgs.owi.nldi.controllers;
 
-import java.io.IOException;
-
-import javax.servlet.http.HttpServletResponse;
-import javax.validation.ConstraintViolationException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -15,7 +10,12 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.validation.ConstraintViolationException;
+import java.io.IOException;
 
 @ControllerAdvice
 public class GlobalDefaultExceptionHandler extends ResponseEntityExceptionHandler {
@@ -40,6 +40,9 @@ public class GlobalDefaultExceptionHandler extends ResponseEntityExceptionHandle
 			} else {
 				return ex.getLocalizedMessage().replaceAll("([a-zA-Z]+\\.)+","");
 			}
+		} else if (ex instanceof ResponseStatusException) {
+			response.setStatus(HttpStatus.BAD_REQUEST.value());
+			return ex.getLocalizedMessage();
 		} else {
 			response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
 			int hashValue = response.hashCode();

--- a/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
@@ -17,11 +17,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -167,6 +169,12 @@ public class NetworkController extends BaseController {
 		String[] coordsArray = tempCoords.split(" ");
 		Double longitude = Double.parseDouble(coordsArray[0]);
 		Double latitude = Double.parseDouble(coordsArray[1]);
+		if (longitude < -90 || longitude > 90) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid longitude");
+		}
+		if (latitude < -90 || latitude > 90) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid latitude");
+		}
 		Map<String, Object> map = new HashMap<>();
 		map.put(Parameters.LATITUDE, latitude);
 		map.put(Parameters.LONGITUDE, longitude);

--- a/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/NetworkController.java
@@ -169,7 +169,7 @@ public class NetworkController extends BaseController {
 		String[] coordsArray = tempCoords.split(" ");
 		Double longitude = Double.parseDouble(coordsArray[0]);
 		Double latitude = Double.parseDouble(coordsArray[1]);
-		if (longitude < -90 || longitude > 90) {
+		if (longitude < -180 || longitude > 180) {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid longitude");
 		}
 		if (latitude < -90 || latitude > 90) {

--- a/src/main/resources/mybatis/lookup.xml
+++ b/src/main/resources/mybatis/lookup.xml
@@ -78,7 +78,7 @@
         select featureid
           from nhdplus.catchmentsp
             where st_intersects(nhdplus.catchmentsp.the_geom,
-              st_setsrid(st_makepoint(#{lon}, #{lat}), 4269)::geography);
+              st_geomfromtext('POINT(${lon} ${lat})', 4269));
     </select>
 
 

--- a/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerPositionIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerPositionIT.java
@@ -66,7 +66,7 @@ public class NetworkControllerPositionIT extends BaseIT {
 	@Test
 	public void getCoordinatesTestOutOfRange() throws Exception {
 		assertEntity(restTemplate,
-			"/linked-data/comid/position?coords=POINT(-100 0)",
+			"/linked-data/comid/position?coords=POINT(-181 0)",
 			HttpStatus.BAD_REQUEST.value(),
 			null,
 			null,
@@ -76,7 +76,7 @@ public class NetworkControllerPositionIT extends BaseIT {
 			false);
 
 		assertEntity(restTemplate,
-			"/linked-data/comid/position?coords=POINT(100 0)",
+			"/linked-data/comid/position?coords=POINT(181 0)",
 			HttpStatus.BAD_REQUEST.value(),
 			null,
 			null,
@@ -86,7 +86,7 @@ public class NetworkControllerPositionIT extends BaseIT {
 			false);
 
 		assertEntity(restTemplate,
-			"/linked-data/comid/position?coords=POINT(0 -100)",
+			"/linked-data/comid/position?coords=POINT(0 -91)",
 			HttpStatus.BAD_REQUEST.value(),
 			null,
 			null,
@@ -96,12 +96,56 @@ public class NetworkControllerPositionIT extends BaseIT {
 			false);
 
 		assertEntity(restTemplate,
-			"/linked-data/comid/position?coords=POINT(0 100)",
+			"/linked-data/comid/position?coords=POINT(0 91)",
 			HttpStatus.BAD_REQUEST.value(),
 			null,
 			null,
 			null,
 			"400 BAD_REQUEST \"Invalid latitude\"",
+			false,
+			false);
+	}
+
+
+	@Test
+	public void getCoordinatesTestInRange() throws Exception {
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(-180 0)",
+			HttpStatus.OK.value(),
+			null,
+			null,
+			null,
+			null,
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(180 0)",
+			HttpStatus.OK.value(),
+			null,
+			null,
+			null,
+			null,
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(0 -90)",
+			HttpStatus.OK.value(),
+			null,
+			null,
+			null,
+			null,
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(0 90)",
+			HttpStatus.OK.value(),
+			null,
+			null,
+			null,
+			null,
 			false,
 			false);
 	}

--- a/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerPositionIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/NetworkControllerPositionIT.java
@@ -1,5 +1,7 @@
 package gov.usgs.owi.nldi.controllers;
 
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import gov.usgs.owi.nldi.BaseIT;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +12,6 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
-
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-
-import gov.usgs.owi.nldi.BaseIT;
 
 @EnableWebMvc
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
@@ -60,6 +58,50 @@ public class NetworkControllerPositionIT extends BaseIT {
 			null,
 			null,
 			null,
+			false,
+			false);
+	}
+
+
+	@Test
+	public void getCoordinatesTestOutOfRange() throws Exception {
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(-100 0)",
+			HttpStatus.BAD_REQUEST.value(),
+			null,
+			null,
+			null,
+			"400 BAD_REQUEST \"Invalid longitude\"",
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(100 0)",
+			HttpStatus.BAD_REQUEST.value(),
+			null,
+			null,
+			null,
+			"400 BAD_REQUEST \"Invalid longitude\"",
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(0 -100)",
+			HttpStatus.BAD_REQUEST.value(),
+			null,
+			null,
+			null,
+			"400 BAD_REQUEST \"Invalid latitude\"",
+			false,
+			false);
+
+		assertEntity(restTemplate,
+			"/linked-data/comid/position?coords=POINT(0 100)",
+			HttpStatus.BAD_REQUEST.value(),
+			null,
+			null,
+			null,
+			"400 BAD_REQUEST \"Invalid latitude\"",
 			false,
 			false);
 	}


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
The query to search for a feature by latitude and longitude was not using the index on nhdplus.catchmentsp.the_geom.  The reason is that the function st_intersects won't use indexes unless the query is very simple.  So rewrite the query so the index gets used.

Description
-----------
https://internal.cida.usgs.gov/jira/browse/NHGF-23

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
