### PR TITLE
Added parameter to allow full resolution boundary to be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.3.0...master)
+* Add `?simplified=false` parameter to retrieve full resolution basin boundary
 
 ## [1.3.0](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.2.0...nldi-services-1.3.0)
 ### Changed

--- a/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/BaseController.java
@@ -109,9 +109,10 @@ public abstract class BaseController {
 		streamResults(transformer, featureType, parameterMap);
 	}
 
-	protected void streamBasin(HttpServletResponse response, String comid) throws Exception {
+	protected void streamBasin(HttpServletResponse response, String comid, Boolean simplified) throws Exception {
 		Map<String, Object> parameterMap = new HashMap<>();
 		parameterMap.put(Parameters.COMID, NumberUtils.parseNumber(comid, Integer.class));
+		parameterMap.put(Parameters.SIMPLIFIED, simplified);
 		BasinTransformer transformer = new BasinTransformer(response);
 		addContentHeader(response);
 		streamResults(transformer, BaseDao.BASIN, parameterMap);

--- a/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/LinkedDataController.java
@@ -244,7 +244,8 @@ public class LinkedDataController extends BaseController {
 	@GetMapping(value="linked-data/{featureSource}/{featureID}/basin", produces=MediaType.APPLICATION_JSON_VALUE)
 	public void getBasin(HttpServletRequest request, HttpServletResponse response,
 			@PathVariable(LookupDao.FEATURE_SOURCE) String featureSource,
-			@PathVariable(Parameters.FEATURE_ID) String featureID) throws Exception {
+			@PathVariable(Parameters.FEATURE_ID) String featureID,
+			@RequestParam(value = Parameters.SIMPLIFIED, required = false, defaultValue = "true") Boolean simplified) throws Exception {
 
 		BigInteger logId = logService.logRequest(request);
 
@@ -254,7 +255,7 @@ public class LinkedDataController extends BaseController {
 			if (null == comid) {
 				response.setStatus(HttpStatus.NOT_FOUND.value());
 			} else {
-				streamBasin(response, comid);
+				streamBasin(response, comid, simplified);
 			}
 		} catch (Exception e) {
 			GlobalDefaultExceptionHandler.handleError(e, response);

--- a/src/main/java/gov/usgs/owi/nldi/services/Parameters.java
+++ b/src/main/java/gov/usgs/owi/nldi/services/Parameters.java
@@ -29,6 +29,7 @@ public class Parameters {
 	public static final String LEGACY = "legacy";
 	public static final String LATITUDE = "lat";
 	public static final String LONGITUDE = "lon";
+	public static final String SIMPLIFIED = "simplified";
 
 	// Validates that the "coords" parameter is in the form POINT(-89.35 43.0864))
 	public static final String POINT_VALIDATION_MESSAGE = "coords must be specified as a point with longitude and latitude, i.e. POINT(-89.35 43.0864)";

--- a/src/main/resources/mybatis/stream.xml
+++ b/src/main/resources/mybatis/stream.xml
@@ -67,7 +67,14 @@
                              x.dnminorhyd = navigation_results.hydroseq))
                    )
         select 1 total_rows,
-               st_asgeojson(st_simplify(st_union(catchmentsp.the_geom), .001)) shape
+                <choose>
+                    <when test="simplified == true">
+                        st_asgeojson(st_simplify(st_union(catchmentsp.the_geom), .001)) shape
+                    </when>
+                    <otherwise>
+                        st_asgeojson(st_union(catchmentsp.the_geom)) shape
+                    </otherwise>
+                </choose>
           from navigation_results
                join characteristic_data.catchmentsp
                  on navigation_results.comid = catchmentsp.featureid

--- a/src/test/java/gov/usgs/owi/nldi/controllers/BaseControllerTest.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/BaseControllerTest.java
@@ -114,7 +114,16 @@ public class BaseControllerTest {
 
 	@Test
 	public void streamBasinTest() throws Exception {
-		controller.streamBasin(response, "123");
+		controller.streamBasin(response, "123", true);
+		verify(streamingDao).stream(anyString(), anyMap(), any(ResultHandler.class));
+		verify(navigation, never()).navigate(anyMap());
+		verify(navigation, never()).interpretResult(anyMap(), any(HttpServletResponse.class));
+		assertEquals(HttpStatus.OK.value(), response.getStatus());
+	}
+
+	@Test
+	public void streamBasinNonSimplifiedTest() throws Exception {
+		controller.streamBasin(response, "123", false);
 		verify(streamingDao).stream(anyString(), anyMap(), any(ResultHandler.class));
 		verify(navigation, never()).navigate(anyMap());
 		verify(navigation, never()).interpretResult(anyMap(), any(HttpServletResponse.class));

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerTest.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerTest.java
@@ -169,7 +169,18 @@ public class LinkedDataControllerTest {
 		when(lookupDao.getComid(anyString(), anyMap())).thenReturn(goodFeature());
 		doNothing().when(streamingDao).stream(anyString(), anyMap(), any());
 
-		controller.getBasin(request, response, "DoesntMatter", "DoesntMatter");
+		controller.getBasin(request, response, "DoesntMatter", "DoesntMatter", true);
+		verify(logService).logRequest(any(HttpServletRequest.class));
+		verify(logService).logRequestComplete(any(BigInteger.class), any(int.class));
+		assertEquals(HttpStatus.OK.value(), response.getStatus());
+	}
+
+	@Test
+	public void getBasinNonSimplifiedTest() throws Exception {
+		when(lookupDao.getComid(anyString(), anyMap())).thenReturn(goodFeature());
+		doNothing().when(streamingDao).stream(anyString(), anyMap(), any());
+
+		controller.getBasin(request, response, "DoesntMatter", "DoesntMatter", false);
 		verify(logService).logRequest(any(HttpServletRequest.class));
 		verify(logService).logRequestComplete(any(BigInteger.class), any(int.class));
 		assertEquals(HttpStatus.OK.value(), response.getStatus());
@@ -177,7 +188,7 @@ public class LinkedDataControllerTest {
 
 	@Test
 	public void getBasinWithNullParamsTest() throws Exception {
-		controller.getBasin(request, response, null, null);
+		controller.getBasin(request, response, null, null, true);
 		verify(logService).logRequest(any(HttpServletRequest.class));
 		verify(logService).logRequestComplete(any(BigInteger.class), any(int.class));
 		//this is a INTERNAL_SERVER_ERROR because of NPEs that shouldn't happen in real life.
@@ -186,7 +197,7 @@ public class LinkedDataControllerTest {
 
 	@Test
 	public void getBasinWithNonexistingComidTest() throws Exception {
-		controller.getBasin(request, response, "NowhereSource", "IDontExist");
+		controller.getBasin(request, response, "NowhereSource", "IDontExist", true);
 		verify(logService).logRequest(any(HttpServletRequest.class));
 		verify(logService).logRequestComplete(any(BigInteger.class), any(int.class));
 		assertEquals(HttpStatus.NOT_FOUND.value(), response.getStatus());


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Added parameter to allow full resolution basin boundary to be retrieved
-----------
Created an additional RequestParam `SIMPLIFIED` that can be specified in the request as `?simplified=false` or `?simplified=true`, otherwise will default to true. This parameter is checked in stream.xml to decide whether to use `st_simplify` or not. I also created two additional tests with the simplification set to false.

JIRA ticket: https://internal.cida.usgs.gov/jira/browse/NHGF-27
Resolves: https://github.com/ACWI-SSWD/nldi-services/issues/171

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
