### PR TITLE
Updated navigation to ignore coastal flowlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.3.0...master)
+* Updated flowline navigation to ignore coastal features
 * Add `?simplified=false` parameter to retrieve full resolution basin boundary
 
 ## [1.3.0](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.2.0...nldi-services-1.3.0)

--- a/src/main/java/gov/usgs/owi/nldi/springinit/MybatisConfig.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/MybatisConfig.java
@@ -27,6 +27,7 @@ public class MybatisConfig {
 		config.setCacheEnabled(false);
 		config.setLazyLoadingEnabled(false);
 		config.setAggressiveLazyLoading(false);
+		config.getVariables().put("coastal_fcode", "56600"); // global constant for coastal feature fcode values
 
 		registerAliases(config.getTypeAliasRegistry());
 

--- a/src/main/resources/mybatis/navigate.xml
+++ b/src/main/resources/mybatis/navigate.xml
@@ -76,7 +76,7 @@
                            nav
                      where x.hydroseq = nav.dnhydroseq and
                            x.terminalpathid = nav.terminalpathid and
-                           x.fcode != 56600
+                           x.fcode != ${coastal_fcode}
                            <if test="null != distance">
                                and x.pathlength + x.lengthkm >= nav.stoplength
                            </if>
@@ -102,7 +102,7 @@
                      where (x.hydroseq = nav.dnhydroseq or
                             (nav.dnminorhyd != 0 and
                              x.hydroseq = nav.dnminorhyd)) and
-                           x.fcode != 56600 and
+                           x.fcode != ${coastal_fcode} and
                            nav.terminalflag != 1
                            <if test="null != distance">
                                and x.pathlength + x.lengthkm >= nav.stoplength
@@ -127,7 +127,7 @@
                            nav
                      where x.hydroseq = nav.uphydroseq and
                            x.levelpathid = nav.levelpathid and
-                           x.fcode != 56600
+                           x.fcode != ${coastal_fcode}
                            <if test="null != distance">
                                and x.pathlength &lt;= nav.stoplength
                            </if>
@@ -153,7 +153,7 @@
                            (x.dnhydroseq = navigation_results.hydroseq or
                             (x.dnminorhyd != 0 and
                              x.dnminorhyd = navigation_results.hydroseq)) and
-                            x.fcode != 56600
+                            x.fcode != ${coastal_fcode}
                            <if test="null != distance">
                                and x.pathlength &lt;= navigation_results.stoplength
                            </if>

--- a/src/main/resources/mybatis/navigate.xml
+++ b/src/main/resources/mybatis/navigate.xml
@@ -65,17 +65,18 @@
 
     <sql id="DM">
         with
-            recursive nav(comid, terminalpathid, dnhydroseq, stoplength)
-                as (select comid, terminalpathid, dnhydroseq,
+            recursive nav(comid, terminalpathid, dnhydroseq, fcode, stoplength)
+                as (select comid, terminalpathid, dnhydroseq, fcode,
                            pathlength + lengthkm <if test="null != distance">- #{distance}</if> stoplength
                       from nhdplus.plusflowlinevaa_np21
                      where comid = #{comid,jdbcType=NUMERIC}
                     union
-                    select x.comid, x.terminalpathid, x.dnhydroseq, nav.stoplength
+                    select x.comid, x.terminalpathid, x.dnhydroseq, x.fcode, nav.stoplength
                       from nhdplus.plusflowlinevaa_np21 x,
                            nav
                      where x.hydroseq = nav.dnhydroseq and
-                           x.terminalpathid = nav.terminalpathid
+                           x.terminalpathid = nav.terminalpathid and
+                           x.fcode != 56600
                            <if test="null != distance">
                                and x.pathlength + x.lengthkm >= nav.stoplength
                            </if>
@@ -88,19 +89,20 @@
 
     <sql id="DD">
         with
-            recursive nav(comid, dnhydroseq, dnminorhyd, stoplength, terminalflag)
-                as (select comid, dnhydroseq, dnminorhyd,
+            recursive nav(comid, dnhydroseq, dnminorhyd, fcode, stoplength, terminalflag)
+                as (select comid, dnhydroseq, dnminorhyd, fcode,
                            pathlength + lengthkm <if test="null != distance">- #{distance}</if> stoplength,
                            terminalflag
                       from nhdplus.plusflowlinevaa_np21
                      where comid = #{comid,jdbcType=NUMERIC}
                     union
-                    select x.comid, x.dnhydroseq, x.dnminorhyd, nav.stoplength, x.terminalflag
+                    select x.comid, x.dnhydroseq, x.dnminorhyd, x.fcode, nav.stoplength, x.terminalflag
                       from nhdplus.plusflowlinevaa_np21 x,
                            nav
                      where (x.hydroseq = nav.dnhydroseq or
                             (nav.dnminorhyd != 0 and
                              x.hydroseq = nav.dnminorhyd)) and
+                           x.fcode != 56600 and
                            nav.terminalflag != 1
                            <if test="null != distance">
                                and x.pathlength + x.lengthkm >= nav.stoplength
@@ -114,17 +116,18 @@
 
     <sql id="UM">
         with
-            recursive nav(comid, levelpathid, uphydroseq, stoplength)
-                as (select comid, levelpathid, uphydroseq,
+            recursive nav(comid, levelpathid, uphydroseq, fcode, stoplength)
+                as (select comid, levelpathid, uphydroseq, fcode,
                            pathlength + 0 <if test="null != distance">+ #{distance}</if> stoplength
                       from nhdplus.plusflowlinevaa_np21
                      where comid = #{comid,jdbcType=NUMERIC}
                     union all
-                    select x.comid, x.levelpathid, x.uphydroseq, nav.stoplength
+                    select x.comid, x.levelpathid, x.uphydroseq, x.fcode, nav.stoplength
                       from nhdplus.plusflowlinevaa_np21 x,
                            nav
                      where x.hydroseq = nav.uphydroseq and
-                           x.levelpathid = nav.levelpathid
+                           x.levelpathid = nav.levelpathid and
+                           x.fcode != 56600
                            <if test="null != distance">
                                and x.pathlength &lt;= nav.stoplength
                            </if>
@@ -137,19 +140,20 @@
 
     <sql id="UT">
         with
-            recursive navigation_results(comid, hydroseq, startflag, stoplength)
-                as (select comid, hydroseq, startflag,
+            recursive navigation_results(comid, hydroseq, startflag, fcode, stoplength)
+                as (select comid, hydroseq, startflag, fcode,
                            pathlength + 0 <if test="null != distance">+ #{distance}</if> stoplength
                       from nhdplus.plusflowlinevaa_np21
                      where comid = #{comid,jdbcType=NUMERIC}
                     union
-                    select x.comid, x.hydroseq, x.startflag, navigation_results.stoplength
+                    select x.comid, x.hydroseq, x.startflag, x.fcode, navigation_results.stoplength
                       from nhdplus.plusflowlinevaa_np21 x,
                            navigation_results
                      where navigation_results.startflag != 1 and
                            (x.dnhydroseq = navigation_results.hydroseq or
                             (x.dnminorhyd != 0 and
-                             x.dnminorhyd = navigation_results.hydroseq))
+                             x.dnminorhyd = navigation_results.hydroseq)) and
+                            x.fcode != 56600
                            <if test="null != distance">
                                and x.pathlength &lt;= navigation_results.stoplength
                            </if>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Updated navigation to ignore coastal flowlines
-----------
Created an fcode check in `navigate.xml` to ignore coastal features (fcode == 56600).

Description
-----------
https://internal.cida.usgs.gov/jira/browse/NHGF-30 
Navigation requests will now stop once they reach a coastal feature. If the request starts on a coastal feature, only that feature will be returned. In order to test using the demo database you will need to create fake coasts. Run the following psql command against the database to create example coasts.
```
update nhdplus.plusflowlinevaa_np21 set fcode = 56600 where comid in (13294304, 13294298, 13294300, 13294310);
```
Test requests can be run using upstream or downstream features. These should end when reaching the Lake Mendota area. Making a request from a coastal feature (localhost:8080/nldi/linked-data/wqp/WIDNR_WQX-10031720/navigation/UT/flowlines?distance=100&f=json) should return only that feature.

Resolves #39 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
