### PR TITLE
NHGF-38 include message with error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.3.0...master)
+### Changed
+* Missing parameter error now returns an informative message
 * Updated flowline navigation to ignore coastal features
+
+### Added
 * Add `?simplified=false` parameter to retrieve full resolution basin boundary
 
 ## [1.3.0](https://github.com/ACWI-SSWD/nldi-services/compare/nldi-services-1.2.0...nldi-services-1.3.0)

--- a/src/main/java/gov/usgs/owi/nldi/controllers/GlobalDefaultExceptionHandler.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/GlobalDefaultExceptionHandler.java
@@ -2,7 +2,9 @@ package gov.usgs.owi.nldi.controllers;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -52,5 +54,15 @@ public class GlobalDefaultExceptionHandler extends ResponseEntityExceptionHandle
 			LOG.error(msgText, ex);
 			return msgText;
 		}
+	}
+
+	@Override
+	protected ResponseEntity<Object> handleMissingServletRequestParameter(
+			MissingServletRequestParameterException ex,
+			HttpHeaders headers,
+			HttpStatus status,
+			WebRequest request
+	) {
+		return new ResponseEntity<>(ex.getLocalizedMessage(), headers, status);
 	}
 }

--- a/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerFlowlineIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/LinkedDataControllerFlowlineIT.java
@@ -109,8 +109,20 @@ public class LinkedDataControllerFlowlineIT extends BaseIT {
 				getCompareFile(RESULT_FOLDER_HUC, "huc12pp_070900020601_DM_distance_empty.json"),
 				true,
 				false);
+	}
 
-
+	@Test
+	@DatabaseSetup("classpath:/testData/featureHuc12pp.xml")
+	public void getHuc12ppDMTestMissingParameter() throws Exception {
+		assertEntity(restTemplate,
+				"/linked-data/huc12pp/070900020601/navigation/DM/flowlines",
+				HttpStatus.BAD_REQUEST.value(),
+				null,
+				null,
+				null,
+				getCompareFile(RESULT_FOLDER_HUC, "huc12pp_070900020601_DM_no_distance.txt"),
+				false,
+				false);
 	}
 
 	@Test

--- a/src/test/resources/testResult/feature/flowline/huc12pp/huc12pp_070900020601_DM_no_distance.txt
+++ b/src/test/resources/testResult/feature/flowline/huc12pp/huc12pp_070900020601_DM_no_distance.txt
@@ -1,0 +1,1 @@
+Required String parameter 'distance' is not present


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
[NHGF-38](https://internal.cida.usgs.gov/jira/browse/NHGF-38)

Description
-----------
Created an override implementation of the `MissingServletRequestParameter` exception handler so that a message with be returned to indicate which required parameter is missing. Closes #205 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
