### PR TITLE
Set options to 0 in st_asgeojson

### DIFF
--- a/src/main/resources/mybatis/lookup.xml
+++ b/src/main/resources/mybatis/lookup.xml
@@ -13,7 +13,7 @@
         feature.comid,
         feature.reachcode,
         feature.measure,
-        st_asgeojson(feature.location) shape
+        st_asgeojson(feature.location, 9, 0) shape
     </sql>
 
     <sql id="comidProperties">
@@ -21,7 +21,7 @@
         'NHDPlus comid' source_name,
         nhdflowline_np21.nhdplus_comid identifier,
         nhdflowline_np21.nhdplus_comid comid,
-        st_asgeojson(nhdflowline_np21.shape) shape
+        st_asgeojson(nhdflowline_np21.shape, 9, 0) shape
     </sql>
 
     <sql id="selectFeatures">

--- a/src/main/resources/mybatis/stream.xml
+++ b/src/main/resources/mybatis/stream.xml
@@ -6,7 +6,7 @@
     <select id="flowLinesLegacy" resultType="java.util.LinkedHashMap" fetchSize="50">
         select count(*) over (partition by 1) total_rows,
                tmp_navigation_results.nhdplus_comid,
-               st_asgeojson(nhdflowline_np21.shape) shape
+               st_asgeojson(nhdflowline_np21.shape, 9, 0) shape
           from nhdplus_navigation.tmp_navigation_results
                join nhdplus.nhdflowline_np21
                  on tmp_navigation_results.nhdplus_comid = nhdflowline_np21.nhdplus_comid 
@@ -17,7 +17,7 @@
         <include refid="navigate.core"/>
         select count(*) over (partition by 1) total_rows,
                nhdplus_comid,
-               st_asgeojson(nhdflowline_np21.shape) shape
+               st_asgeojson(nhdflowline_np21.shape, 9, 0) shape
           from navigation_results
                join nhdplus.nhdflowline_np21
                  on navigation_results.comid = nhdflowline_np21.nhdplus_comid
@@ -69,10 +69,10 @@
         select 1 total_rows,
                 <choose>
                     <when test="simplified == true">
-                        st_asgeojson(st_simplify(st_union(catchmentsp.the_geom), .001)) shape
+                        st_asgeojson(st_simplify(st_union(catchmentsp.the_geom), .001), 9, 0) shape
                     </when>
                     <otherwise>
-                        st_asgeojson(st_union(catchmentsp.the_geom)) shape
+                        st_asgeojson(st_union(catchmentsp.the_geom), 9, 0) shape
                     </otherwise>
                 </choose>
           from navigation_results


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [ ] Update the changelog appropriately

Description
-----------
Setting options to 0 prevents additional attributes from being added with postgis 3.0.0.
https://postgis.net/docs/ST_AsGeoJSON.html
`ST_AsGeoJSON(geometry geom, integer maxdecimaldigits=9, integer options=8);`

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
