### PR TITLE
update pipeline version reference in gitlab ci yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
   - project: "wma/nhgf/nldi/mirror-pipelines"
-    ref: "2024-04-04-r4"
+    ref: "2025-08-21-r0"
     file:
       - "nldi-services.yml"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+# This will be where nldi-py releases are specified for prod builds of
+# the nldi-services image.  
+ARG IMAGE_VERSION=2.11
 
-FROM ghcr.io/internetofwater/nldi-py:2.1.1
+FROM ghcr.io/internetofwater/nldi-py:${IMAGE_VERSION}
 
 COPY nldi.server.yml nldi.source.yml /tmp/
 


### PR DESCRIPTION
Trivial PR for updating pipeline reference to updated version supporting default 'alpha' pull for dev.